### PR TITLE
Restore max icon size at 24px

### DIFF
--- a/src/AyatanaIndicator.vala
+++ b/src/AyatanaIndicator.vala
@@ -33,7 +33,7 @@ public class AyatanaCompatibility.Indicator : Wingpanel.Indicator {
 	private Gee.HashMap<Gtk.Widget, Gtk.Widget> submenu_map;
 	
     const int MAX_ICON_SIZE = 24;
-    const int IDEAL_ICON_SIZE = 18;
+    const int IDEAL_ICON_SIZE = 24;
     
 	//grouping radio buttons
 	private Gtk.RadioButton? group_radio=null ;


### PR DESCRIPTION
Restore the max size cap set by eth-p back to 24px from 18px, as per the original.
Info found here: https://github.com/eth-p/wingpanel-indicator-ayatana/issues/9